### PR TITLE
node12 -> node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: 'A github token'
     required: true
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
# やったこと

タイトル通り。18はgh側的にまだっぽい？
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

バージョン差異で動かなくなる可能性あるかもなので、
そのへんはまた追々修正します。