### PR TITLE
feat: 必須レビュアーを設定できるようにした

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,3 +12,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PAT_REPO }}
           REVIEWERS: 'hard-boiled'
           TEAM_REVIEWERS: 'for-test-action'
+          MUST_TEAM_REVIEWERS: 'employee-eng'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,10 @@ jobs:
   test: # make sure the action works on a clean machine without building
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./
         with:
           GITHUB_TOKEN: ${{ secrets.PAT_REPO }}
-          REVIEWERS: 'hard-boiled'
-          TEAM_REVIEWERS: 'for-test-action'
-          MUST_TEAM_REVIEWERS: 'employee-eng'
+          REVIEWERS: "hard-boiled"
+          TEAM_REVIEWERS: "for-test-action"
+          MUST_TEAM_REVIEWERS: "employee-eng"

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,13 +28,16 @@ async function run(): Promise<void> {
     if (pullRequest.draft) return
 
     const requestedReviewersNum = pullRequest.requested_reviewers?.length ?? 0
-    const [additionalReviewers, additionalTeamReviewers] =
+
+    const additionalReviewers =
       requestedReviewersNum > 0
-        ? [mustReviewers, mustTeamReviewers]
-        : [
-            [...reviewers, ...mustReviewers],
-            [...teamReviewers, ...mustTeamReviewers],
-          ]
+        ? mustReviewers
+        : [...reviewers, ...mustReviewers]
+
+    const additionalTeamReviewers =
+      requestedReviewersNum > 0
+        ? mustTeamReviewers
+        : [...teamReviewers, ...mustTeamReviewers]
 
     // 追加するべきレビュアーがいない場合はなにもしない
     if (additionalReviewers.length + additionalTeamReviewers.length) return

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,8 @@ async function run(): Promise<void> {
     const token = core.getInput('GITHUB_TOKEN', { required: true })
     const reviewers = core.getInput('REVIEWERS').split(',')
     const teamReviewers = core.getInput('TEAM_REVIEWERS').split(',')
+    const mustReviewers = core.getInput('MUST_REVIEWERS').split(',')
+    const mustTeamReviewers = core.getInput('MUST_TEAM_REVIEWERS').split(',')
 
     const octokit = github.getOctokit(token)
 
@@ -25,16 +27,24 @@ async function run(): Promise<void> {
     // PRがドラフトだったらなにもしない
     if (pullRequest.draft) return
 
-    // PRにレビュワーがアサインされてたら追加アサインしない
     const requestedReviewersNum = pullRequest.requested_reviewers?.length ?? 0
-    if (requestedReviewersNum > 0) return
+    const [additionalReviewers, additionalTeamReviewers] =
+      requestedReviewersNum > 0
+        ? [mustReviewers, mustTeamReviewers]
+        : [
+            [...reviewers, ...mustReviewers],
+            [...teamReviewers, ...mustTeamReviewers],
+          ]
+
+    // 追加するべきレビュアーがいない場合はなにもしない
+    if (additionalReviewers.length + additionalTeamReviewers.length) return
 
     await octokit.pulls.requestReviewers({
       owner,
       repo,
       pull_number,
-      reviewers,
-      team_reviewers: teamReviewers,
+      reviewers: additionalReviewers,
+      team_reviewers: additionalTeamReviewers,
     })
   } catch (error) {
     core.setFailed(error.message)


### PR DESCRIPTION
# Overview
PR作成時に手動でReviewersに追加されている場合でも、必ず追加される必須レビュアーを設定できる機能を追加。

- きっかけ: 
  - https://400f-jp.slack.com/archives/CJ5D8029J/p1709787855470849?thread_ts=1709787737.454469&cid=CJ5D8029J
  - https://400f-jp.slack.com/archives/CEYLB6DDM/p1709702101459039
  
(ブランチ名typoしてるのは気にしないで)

# 本件以外の変更
- [update: actions/checkoutをv4にアップデート](https://github.com/400f/action-assign-reviewers/pull/9/commits/ef943a2d52e992832c851e3d1c3db04e7e27508c)