### PR TITLE
fix: MUST_REVIEWERSとMUST_TEAM_REVIEWERSをinputとして追加

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,12 @@ inputs:
   TEAM_REVIEWERS:
     description: 'team reviewers'
     default: ''
+  MUST_REVIEWERS:
+    description: 'must reviewers (always added)'
+    default: ''
+  MUST_TEAM_REVIEWERS:
+    description: 'must team reviewers (always added)'
+    default: ''
   GITHUB_TOKEN:
     description: 'A github token'
     required: true

--- a/action.yml
+++ b/action.yml
@@ -18,5 +18,5 @@ inputs:
     description: 'A github token'
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
# Overview
https://github.com/400f/action-assign-reviewers/pull/9 で対応が漏れていたaction.ymlの修正を行った。
具体的には、必ず追加されるレビュアーを設定する項目として、`MUST_REVIEWERS` `MUST_TEAM_REVIEWERS` を新たに追加しているので、それをaction.ymlでinputとして認識されるようにした。

# レビューポイント
特に見てもらうところはないと思うが、もし「認識間違ってるよ」とかtypo等あれば指摘してもらえると。